### PR TITLE
Minor changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ project( Malmo )
 # -------------------- Options --------------------------------
 
 set( MALMO_VERSION_MAJOR 0)
-set( MALMO_VERSION_MINOR 17)
+set( MALMO_VERSION_MINOR 18)
 set( MALMO_VERSION_REVISION 0)
 set( MALMO_VERSION ${MALMO_VERSION_MAJOR}.${MALMO_VERSION_MINOR}.${MALMO_VERSION_REVISION} )
 # N.B. Check that this version number matches the one in Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MalmoMod.java
@@ -67,7 +67,7 @@ import com.microsoft.Malmo.Utils.ScreenHelper;
 public class MalmoMod
 {
     public static final String MODID = "malmomod";
-    public static final String VERSION = "0.17.0"; // N.B. Check that this version number matches the one in the root CMakeLists.txt and the Schemas.
+    public static final String VERSION = "0.18.0"; // N.B. Check that this version number matches the one in the root CMakeLists.txt and the Schemas.
     public static final String SOCKET_CONFIGS = "malmoports";
     public static final String DIAGNOSTIC_CONFIGS = "malmodiags";
     public static final String AUTHENTICATION_CONFIGS = "malmologins";

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/DefaultWorldGeneratorImplementation.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/DefaultWorldGeneratorImplementation.java
@@ -77,7 +77,7 @@ public class DefaultWorldGeneratorImplementation extends HandlerBase implements 
         worldsettings.enableCommands();
         // Create a filename for this map - we use the time stamp to make sure it is different from other worlds, otherwise no new world
         // will be created, it will simply load the old one.
-        return MapFileHelper.createAndLaunchWorld(worldsettings, this.dwparams.isDestroyAfterMission());
+        return MapFileHelper.createAndLaunchWorld(worldsettings, this.dwparams.isDestroyAfterUse());
     }
 
     @Override

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/FileWorldGeneratorImplementation.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/FileWorldGeneratorImplementation.java
@@ -67,7 +67,7 @@ public class FileWorldGeneratorImplementation extends HandlerBase implements IWo
             this.errorDetails = "Basemap location " + this.mapFilename + " needs to be a folder. Check the path in your Mission XML.";
             return false;
         }
-        File mapCopy = MapFileHelper.copyMapFiles(mapSource, true);
+        File mapCopy = MapFileHelper.copyMapFiles(mapSource, this.fwparams.isDestroyAfterUse());
         if (mapCopy == null)
         {
             this.errorDetails = "Unable to copy " + this.mapFilename + " - is the hard drive full?";
@@ -87,6 +87,7 @@ public class FileWorldGeneratorImplementation extends HandlerBase implements IWo
             this.errorDetails = "Minecraft could not load " + this.mapFilename + " - is it a valid saved world?";
             return false;
         }
+        MapFileHelper.cleanupTemporaryWorlds(mapCopy.getName());    // Now we are safely running a new file, we can attempt to clean up old ones.
         return true;
     }
     

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/FlatWorldGeneratorImplementation.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/FlatWorldGeneratorImplementation.java
@@ -56,7 +56,7 @@ public class FlatWorldGeneratorImplementation extends HandlerBase implements IWo
         worldsettings.enableCommands(); // Enables cheat commands.
         // Create a filename for this map - we use the time stamp to make sure it is different from other worlds, otherwise no new world
         // will be created, it will simply load the old one.
-        return MapFileHelper.createAndLaunchWorld(worldsettings, this.fwparams.isDestroyAfterMission());
+        return MapFileHelper.createAndLaunchWorld(worldsettings, this.fwparams.isDestroyAfterUse());
     }
 
     @Override

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Utils/MapFileHelper.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Utils/MapFileHelper.java
@@ -21,20 +21,15 @@ package com.microsoft.Malmo.Utils;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.client.AnvilConverterException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.WorldSettings;
 import net.minecraft.world.storage.ISaveFormat;
-import net.minecraft.world.storage.ISaveHandler;
-import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraft.world.storage.SaveFormatComparator;
-import net.minecraft.world.storage.SaveHandler;
-import net.minecraft.world.storage.WorldInfo;
+import net.minecraftforge.fml.client.FMLClientHandler;
 
 import org.apache.commons.io.FileUtils;
 
@@ -43,12 +38,14 @@ import org.apache.commons.io.FileUtils;
  */
 public class MapFileHelper
 {
+    static final String tempMark = "TEMP_";
+
     /** Attempt to copy the specified file into the Minecraft saves folder.
      * @param mapFile full path to the map file required
      * @param overwriteOldFiles if false, will rename copy to avoid overwriting any other saved games
      * @return if successful, a File object representing the new copy, which can be fed to Minecraft to load - otherwise null.
      */
-    static public File copyMapFiles(File mapFile, boolean overwriteOldFiles)
+    static public File copyMapFiles(File mapFile, boolean isTemporary)
     {
         System.out.println("Current directory: "+System.getProperty("user.dir"));
         // Look for the basemap file.
@@ -58,24 +55,10 @@ public class MapFileHelper
         File dst = null;
         if (mapFile != null && mapFile.exists())
         {
-            String name = mapFile.getName();
-            dst = new File(savesDir, name);
-            int version = 0;
-            // Avoid name collisions, if we are not allowed to overwrite old files:
-            while (dst.exists() && !overwriteOldFiles)
-            {
-                dst = new File(savesDir, name + "_" + version);
-                version++;
-            }
+            dst = new File(savesDir, getNewSaveFileLocation(isTemporary));
+
             try
             {
-                if (dst.exists() && overwriteOldFiles)
-                {
-                    // Safest to empty out the destination directory, since copyDirectory will just
-                    // copy across the source files, merging them in to the destination. This could result in
-                    // odd behaviour as two Minecraft saved worlds get merged.
-                    FileUtils.deleteDirectory(dst);
-                }
                 FileUtils.copyDirectory(mapFile, dst);
             }
             catch (IOException e)
@@ -88,44 +71,69 @@ public class MapFileHelper
         return dst;
     }
 
+    /** Get a filename to use for creating a new Minecraft save map.<br>
+     * Ensure no duplicates.
+     * @param isTemporary mark the filename such that the file management code knows to delete this later
+     * @return a unique filename (relative to the saves folder)
+     */
+    public static String getNewSaveFileLocation(boolean isTemporary) {
+        File dst;
+        File savesDir = FMLClientHandler.instance().getSavesDir();
+        do {
+            // We used to create filenames based on the current date/time, but this can cause problems when
+            // multiple clients might be writing to the same save location. Instead, use a GUID:
+            String s = UUID.randomUUID().toString();
+
+            // Add our port number, to help with file management:
+            s = AddressHelper.getMissionControlPort() + "_" + s;
+
+            // If this is a temp file, mark it as such:
+            if (isTemporary) {
+                s = tempMark + s;
+            }
+
+            dst = new File(savesDir, s);
+        } while (dst.exists());
+
+        return dst.getName();
+    }
     /**
      * Creates and launches a unique world according to the settings. 
      * @param worldsettings the world's settings
      * @param isTemporary if true, the world will be deleted whenever newer worlds are created
      * @return
      */
-	public static boolean createAndLaunchWorld(WorldSettings worldsettings, boolean isTemporary) {
-
-        String s = SimpleDateFormat.getDateTimeInstance().format(new Date()).replace(":", "_");
-        if (isTemporary){
-            s = "TEMP_"+s;
-        }
+    public static boolean createAndLaunchWorld(WorldSettings worldsettings, boolean isTemporary)
+    {
+        String s = getNewSaveFileLocation(isTemporary);
         Minecraft.getMinecraft().launchIntegratedServer(s, s, worldsettings);
         cleanupTemporaryWorlds(s);
         return true;
-	}
+    }
 
-	/**
-	 * Attempts to delete all Minecraft Worlds with "TEMP_" in front of the name
-	 * @param currentWorld excludes this world from deletion, can be null
-	 */
-	public static void cleanupTemporaryWorlds(String currentWorld){
-		List<SaveFormatComparator> saveList;
-		ISaveFormat isaveformat = Minecraft.getMinecraft().getSaveLoader();
-		isaveformat.flushCache();
+    /**
+     * Attempts to delete all Minecraft Worlds with "TEMP_" in front of the name
+     * @param currentWorld excludes this world from deletion, can be null
+     */
+    public static void cleanupTemporaryWorlds(String currentWorld){
+        List<SaveFormatComparator> saveList;
+        ISaveFormat isaveformat = Minecraft.getMinecraft().getSaveLoader();
+        isaveformat.flushCache();
 
-		try{
-			saveList = isaveformat.getSaveList();
-		} catch (AnvilConverterException e){
-			e.printStackTrace();
-			return;
-		}
+        try{
+            saveList = isaveformat.getSaveList();
+        } catch (AnvilConverterException e){
+            e.printStackTrace();
+            return;
+        }
 
-		for (SaveFormatComparator s: saveList){
-			String folderName = s.getFileName();
-			if (folderName.startsWith("TEMP_") && !folderName.equals(currentWorld)){
-				isaveformat.deleteWorldDirectory(folderName);
-			}
-		}
-	}
+        String searchString = tempMark + AddressHelper.getMissionControlPort() + "_";
+
+        for (SaveFormatComparator s: saveList){
+            String folderName = s.getFileName();
+            if (folderName.startsWith(searchString) && !folderName.equals(currentWorld)){
+                isaveformat.deleteWorldDirectory(folderName);
+            }
+        }
+    }
 }

--- a/Schemas/Mission.xsd
+++ b/Schemas/Mission.xsd
@@ -6,7 +6,7 @@
            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
            elementFormDefault="qualified"
            jaxb:version="2.1"
-           version="0.17">
+           version="0.18">
 
     <xs:include schemaLocation="Types.xsd" /> 
     <xs:include schemaLocation="MissionHandlers.xsd" /> 

--- a/Schemas/MissionEnded.xsd
+++ b/Schemas/MissionEnded.xsd
@@ -4,7 +4,7 @@
            targetNamespace="http://ProjectMalmo.microsoft.com"
            xmlns="http://ProjectMalmo.microsoft.com"
            elementFormDefault="qualified"
-           version="0.17">
+           version="0.18">
            
 <xs:include schemaLocation="MissionHandlers.xsd" />
 

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -6,7 +6,7 @@
            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
            elementFormDefault="qualified"
            jaxb:version="2.1"
-           version="0.17">
+           version="0.18">
 
   <xs:include schemaLocation="Types.xsd" />
 

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -94,7 +94,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="destroyAfterMission" use="optional" type="xs:boolean" default="false">
+      <xs:attribute name="destroyAfterUse" use="optional" type="xs:boolean" default="true">
         <xs:annotation>
           <xs:documentation>
             Set this to true to force the world data files to be deleted after the mission is done.
@@ -127,7 +127,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="destroyAfterMission" use="optional" type="xs:boolean" default="false">
+      <xs:attribute name="destroyAfterUse" use="optional" type="xs:boolean" default="true">
         <xs:annotation>
           <xs:documentation>
             Set this to true to force the world data files to be deleted after the mission is done.
@@ -161,6 +161,14 @@
           <xs:documentation>
             Set this to true to force the world to be reloaded, otherwise the current world will be used (provided it matches the requested source filename).
             Force reloading is slow, but will guarantee that no world changes will carry over between missions.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+       <xs:attribute name="destroyAfterUse" use="optional" type="xs:boolean" default="true">
+        <xs:annotation>
+          <xs:documentation>
+            Set this to true to force the world data files to be deleted after the mission is done.
+            Enabling this setting prevents the disk being filled with old worlds.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>

--- a/Schemas/MissionInit.xsd
+++ b/Schemas/MissionInit.xsd
@@ -4,7 +4,7 @@
            targetNamespace="http://ProjectMalmo.microsoft.com"
            xmlns="http://ProjectMalmo.microsoft.com"
            elementFormDefault="qualified"
-           version="0.17">
+           version="0.18">
            
 <xs:include schemaLocation="Mission.xsd" />
 

--- a/Schemas/Types.xsd
+++ b/Schemas/Types.xsd
@@ -6,7 +6,7 @@
            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
            elementFormDefault="qualified"
            jaxb:version="2.1"
-           version="0.17">
+           version="0.18">
 
 <xs:simpleType name="Colour">
     <xs:annotation>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.17.1
 -------------------
+New: [BREAKING CHANGE] Mission worlds are now deleted after use unless destroyAfterUse is false. (#76)
 Fix: ContinuousMovementCommands now allow the setting of yaw/pitch by Discrete or Absolute movement commands. (#255)
 
 0.17.0 (2016-08-16)


### PR DESCRIPTION
This is excellent work, thank you for doing it.

A few very small things:
- I renamed `destroyAfterMission` to `destroyAfterUse`, because the world will be used for multiple missions if `forceReset` is false.
- I changed the default from false to true - this is a more drastic change, but I think it's the correct default behaviour.
- I've updated the minor version number because of the change to the XSD.

Other changes:
- Thanks to your observation about multiple clients running at once (good spot - I'd not thought of this at all!) I've added the port number to the filename. I'm sure there are still ways to make this go wrong, but in theory two active clients will, of necessity, have two different port numbers, so they should never attempt to delete each other's files.
- I've changed FileWorldGenerator; it used to do its own thing, but I've made it behave the same way as the other generators. I think this is cleaner.
- While looking at that, I started to worry about a race condition in the code which checks for existing filenames... with two clients running simultaneously, basing the filenames off the current time, it would be possible for both to choose the same filename, check that it doesn't already exist, and then both go ahead and create it. Because the time used for the filename has a granularity of one second, it would be pretty easy for this to happen. (And one thing I've learned with Reinforcement Learning is that an obscure and unlikely race condition is almost guaranteed to occur once researchers start running thousands of iterations...) A related problem with the one-second granularity is that (especially with overclocking) missions can easily last less than a second. For these reasons I've ditched the time-based filename and moved to a random GUID-based one.

I've done a small amount of testing on this and haven't (yet) found any problems.
